### PR TITLE
INT: Remove hard dependency on swift lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "cordova-plugin-documentpicker",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "iOS plugin for Cordova writting in Swift.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/iampossible/Cordova-DocPicker"
   },
   "keywords": ["cordova", "plugin", "documentpicker", "icloud", "filebrowser"],
   "author": "Impossible",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-documentpicker" version="0.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-documentpicker" version="1.2.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>DocumentPicker</name>
 
     <platform name="ios">
@@ -15,7 +15,7 @@
 
         <source-file src="src/ios/DocumentPicker.swift" />
 
-        <dependency id="cordova-plugin-add-swift-support" version="1.6.1"/>
+        <dependency id="cordova-plugin-add-swift-support"/>
     </platform>
 
 </plugin>


### PR DESCRIPTION
Fixes #7

- Remove hard dependency on `cordova-plugin-add-swift-support`
- Fix wrong version on `plugin.xml`